### PR TITLE
install_requiresに指定するパッケージをPipfileから取得するよう変更

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include requirements.txt
+include Pipfile

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-click==7.1.2
-pyperclip==1.8.0

--- a/setup.py
+++ b/setup.py
@@ -9,15 +9,17 @@ def _requires_from_file(filename):
     is_in_packages = False
     requires = []
 
-    with open(filename) as f:
-        for r in f:
-            r = r.strip()
-            if r == '[packages]':
+    with open(filename) as _f:
+        for _r in _f:
+            _r = _r.strip()
+            if _r == '[packages]':
                 is_in_packages = True
-            elif r.startswith('['):
+            elif _r.startswith('['):
                 is_in_packages = False
-            elif r and is_in_packages:
-                requires.append(r.replace('"', '').replace(' ', '').replace('=', '', 1))
+            elif _r and is_in_packages:
+                requires.append(_r.replace('"', '')
+                                .replace(' ', '')
+                                .replace('=', '', 1))
 
     return requires
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,20 @@ from setuptools import setup
 
 
 def _requires_from_file(filename):
-    return open(filename).read().splitlines()
+    is_in_packages = False
+    requires = []
+
+    with open(filename) as f:
+        for r in f:
+            r = r.strip()
+            if r == '[packages]':
+                is_in_packages = True
+            elif r.startswith('['):
+                is_in_packages = False
+            elif r and is_in_packages:
+                requires.append(r.replace('"', '').replace(' ', '').replace('=', '', 1))
+
+    return requires
 
 
 setup(
@@ -16,7 +29,7 @@ setup(
     description="突然の死(ハリフキダシ)を生成するツール",
     author="koluku",
     url="https://github.com/koluku/sudden-death",
-    install_requires=_requires_from_file('requirements.txt'),
+    install_requires=_requires_from_file('Pipfile'),
     packages=['sudden_death'],
     package_data={
         "sudden_death": ["py.typed"],


### PR DESCRIPTION
install_requiresに指定するパッケージをPipfileから取得するようにすることで、 `requirements.txt` と `Pipfile` が並存している状態から脱します。