### PR TITLE
CI共通化

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [develop, master]
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [master]

--- a/.github/workflows/pr-release.yml
+++ b/.github/workflows/pr-release.yml
@@ -1,0 +1,79 @@
+name: pr-release
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  # リリース用のPRを作成するjob
+  pr-release:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.8]
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get diff
+        id: get_diff
+        run: |
+          result=$(git diff origin/develop origin/master)
+          echo "${result}"
+          result="${result//$'\n'/'%0A'}"
+          result="${result//$'\r'/'%0D'}"
+          echo "::set-output name=result::${result}"
+      - name: Create PullRequest
+        uses: actions/github-script@v3
+        if: steps.get_diff.outputs.result != ''
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const common_params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            }
+            const pull_params = {
+              head: "develop",
+              base: "refs/heads/master",
+              ...common_params
+            }
+            const pulls_list_params = {
+              state: "open",
+              ...pull_params
+            }
+            console.log("call pulls.list:")
+            console.log(pulls_list_params)
+            github.pulls.list(pulls_list_params).then(list_res => {
+              if (list_res.data.filter(data => data.user.id === 41898282).length === 0) {
+                const pulls_create_params = {
+                  title: "リリース",
+                  body: "鳩は唐揚げになるため、片栗粉へ飛び込む",
+                  draft: true,
+                  ...pull_params
+                }
+                console.log("call pulls.create:")
+                console.log(pulls_create_params)
+                github.pulls.create(pulls_create_params).then(create_res => {
+                  const release_users = ["nakkaa"]
+                  const pulls_create_review_request_params = {
+                    pull_number: create_res.data.number,
+                    reviewers: release_users,
+                    ...common_params
+                  }
+                  console.log("call pulls.createReviewRequest:")
+                  console.log(pulls_create_review_request_params)
+                  github.pulls.createReviewRequest(pulls_create_review_request_params)
+                  const issues_add_assignees_params = {
+                    issue_number: create_res.data.number,
+                    assignees: release_users,
+                    ...common_params
+                  }
+                  console.log("call issues.addAssignees:")
+                  console.log(issues_add_assignees_params)
+                  github.issues.addAssignees(issues_add_assignees_params)
+                })
+              }
+            })

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -433,7 +433,7 @@ jobs:
           WORKON_HOME: ""
           PYTHONPATH: "/github/workspace/:\
             /github/workflow/.venv/lib/python${{ matrix.python-version }}/site-packages"
-  
+
   pr-docker:
     runs-on: ubuntu-latest
 
@@ -441,7 +441,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: check exist setup directory
+      - name: Check exist setup directory
         run: |
           if [ -d setup ]
           then

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -441,17 +441,19 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Exit if setup directory does not exist
+      - name: check exist setup directory
+        id: check_exist_setup
         run: |
           if [ ! -d setup ]
           then
-            echo "Setup directory does not exist. So this job will be skipped."
-            exit 0
+            exit 1
           fi
       - name: Set .env
+        if: steps.check_exist_setup.outcome == 'failure'
         run: |
           cp .env.example .env
       - name: Build docker image
+        if: steps.check_exist_setup.outcome == 'failure'
         run: |
           cd setup
           docker-compose build --no-cache

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -442,18 +442,19 @@ jobs:
         with:
           fetch-depth: 0
       - name: check exist setup directory
-        id: check_exist_setup
         run: |
-          if [ ! -d setup ]
+          if [ -d setup ]
           then
-            exit 1
+            echo "::set-output name=is_exist_setup::true"
+          else
+            echo "::set-output name=is_exist_setup::false"
           fi
       - name: Set .env
-        if: steps.check_exist_setup.outcome == 'failure'
+        if: steps.lint.outputs.is_exist_setup == 'true'
         run: |
           cp .env.example .env
       - name: Build docker image
-        if: steps.check_exist_setup.outcome == 'failure'
+        if: steps.lint.outputs.is_exist_setup == 'true'
         run: |
           cd setup
           docker-compose build --no-cache

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -452,7 +452,10 @@ jobs:
       - name: Set .env
         if: steps.lint.outputs.is_exist_setup == 'true'
         run: |
-          cp .env.example .env
+          if [ -e .env.example ]
+          then
+            cp .env.example .env
+          fi
       - name: Build docker image
         if: steps.lint.outputs.is_exist_setup == 'true'
         run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -199,7 +199,10 @@ jobs:
           pipenv install --dev
       - name: Set .env
         run: |
-          cp .env.example .env
+          if [ -e .env.example ]
+          then
+            cp .env.example .env
+          fi
       - name: Test
         run: |
           pipenv run python -m unittest
@@ -438,8 +441,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Set .env	
-        run: |	
+      - name: Exit if setup directory does not exist
+        run: |
+          if [ ! -d setup ]
+          then
+            exit 1
+          fi
+      - name: Set .env
+        run: |
           cp .env.example .env
       - name: Build docker image
         run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -197,6 +197,9 @@ jobs:
       - name: Install dependencies
         run: |
           pipenv install --dev
+      - name: Set .env
+        run: |
+          cp .env.example .env
       - name: Test
         run: |
           pipenv run python -m unittest
@@ -342,6 +345,18 @@ jobs:
         if: github.event.pull_request.head.repo.full_name != github.repository && !contains(steps.lint.outputs.result, 'Your code has been rated at 10.00/10')
         run: exit 1
 
+  hadolint:
+    name: runner / hadolint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v1
+      - name: hadolint
+        uses: reviewdog/action-hadolint@v1
+        with:
+          level: warning
+          filter_mode: nofilter
+
   pr-super-lint:
     runs-on: ubuntu-latest
     strategy:
@@ -415,3 +430,18 @@ jobs:
           WORKON_HOME: ""
           PYTHONPATH: "/github/workspace/:\
             /github/workflow/.venv/lib/python${{ matrix.python-version }}/site-packages"
+  
+  pr-docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set .env	
+        run: |	
+          cp .env.example .env
+      - name: Build docker image
+        run: |
+          cd setup
+          docker-compose build --no-cache

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -442,6 +442,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check exist setup directory
+        id: check
         run: |
           if [ -d setup ]
           then
@@ -450,14 +451,14 @@ jobs:
             echo "::set-output name=is_exist_setup::false"
           fi
       - name: Set .env
-        if: steps.lint.outputs.is_exist_setup == 'true'
+        if: steps.check.outputs.is_exist_setup == 'true'
         run: |
           if [ -e .env.example ]
           then
             cp .env.example .env
           fi
       - name: Build docker image
-        if: steps.lint.outputs.is_exist_setup == 'true'
+        if: steps.check.outputs.is_exist_setup == 'true'
         run: |
           cd setup
           docker-compose build --no-cache

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -445,7 +445,8 @@ jobs:
         run: |
           if [ ! -d setup ]
           then
-            exit 1
+            echo "Setup directory does not exist. So this job will be skipped."
+            exit 0
           fi
       - name: Set .env
         run: |


### PR DESCRIPTION
CIを可能な限り https://github.com/dev-hato/hato-bot と共通化します。
今のところ、以下の差分を適用すればhato-botのCIをそのまま持ってこれるようになっています。

```diff
diff --git a/.github/workflows/codeql-analysis.yml b/.github/workflows/codeql-analysis.yml
index 8439c88..a2be3dd 100644
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,7 +5,7 @@ on:
     branches: [develop, master]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [develop]
+    branches: [master]
   schedule:
     - cron: '0 21 * * 0'
```

ref: https://github.com/dev-hato/hato-bot/pull/307