### PR TITLE
dependabotが1度に投げるPRの数を制限する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,14 @@ updates:
   directory: "/"
   schedule:
     interval: "monthly"
+  open-pull-requests-limit: 1
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
     interval: "monthly"
+  open-pull-requests-limit: 1
 - package-ecosystem: npm
   directory: "/"
   schedule:
     interval: "monthly"
+  open-pull-requests-limit: 1


### PR DESCRIPTION
dependabotが1度に投げるPRの数をそれぞれ1つずつにします。