### PR TITLE
Revert "Bump click from 7.1.2 to 8.0.1"

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,4 +10,4 @@ mypy = "==0.812"
 
 [packages]
 pyperclip = ">=1.5.27"
-click = "==8.0.1"
+click = "==7.1.2"


### PR DESCRIPTION
hato-botにおいて、slackeventsapiが間接的に依存しているclickとバージョンの不整合を起こしているため ( https://github.com/dev-hato/hato-bot/pull/604 )、 dev-hato/sudden-death#85 をRevertします。