### PR TITLE
mypyアップデート

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 pylint = "==2.9.3"
 autopep8 = "==1.5.7"
-mypy = "==0.812"
+mypy = "==0.910"
 
 [packages]
 pyperclip = ">=1.5.27"

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 pylint = "==2.9.3"
 autopep8 = "==1.5.7"
 mypy = "==0.910"
+types-click = "==7.1.2"
 
 [packages]
 pyperclip = ">=1.5.27"


### PR DESCRIPTION
https://github.com/dev-hato/sudden-death/pull/94 をベースにmypyをアップデートします。
以下のエラーに対処するため、types-clickを追加しています。

https://github.com/dev-hato/sudden-death/pull/94/checks?check_run_id=2967781127

```
sudden_death/__init__.py:9: error: Skipping analyzing "click": found module but no type hints or library stubs
sudden_death/__init__.py:9: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
```