### PR TITLE
pylint削除

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,7 +4,6 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
-pylint = "==2.9.3"
 autopep8 = "==1.5.7"
 mypy = "==0.910"
 types-click = "==7.1.2"


### PR DESCRIPTION
pylintはpr-super-lintで実行する形にしたため、インストールするパッケージからpylintを除外します。