### PR TITLE
click周りで不整合が起きないようslackeventsapiを依存関係に追加する

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -11,3 +11,4 @@ types-click = "==7.1.2"
 [packages]
 pyperclip = ">=1.5.27"
 click = "==7.1.2"
+slackeventsapi = "==2.2.1"


### PR DESCRIPTION
https://github.com/dev-hato/sudden-death/pull/88
hato-botにおいてslackeventsapiはclickに依存しています。
clickをアップデートすることで、slackeventsapiとの不整合が起きないよう、slackeventsapiを依存パッケージとして追加します。