### PR TITLE
secretlintの設定方法をREADMEに記述

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,40 @@ sd.pyを実行することで次に入力した文字が吹き出しになって
 pipenv run python sd.py メッセージ
 ```
 
+## コミットする前に行うこと
+
+誤ってクレデンシャルをコミットしないよう、以下のhookを設定します。
+
+1. 以下のスクリプトを `.git/hooks/pre-commit` として保存します。
+
+    <!-- markdownlint-disable MD013 -->
+    ```sh
+    #!/bin/bash
+    source `dirname ${0}`/_local-hook-exec
+    declare scriptDir=$(cd $(dirname $0);pwd)
+    declare parentDir="$(dirname "${scriptDir}")"
+    declare FILES=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
+    [ -z "$FILES" ] && exit 0
+    echo "  ▶ Check credentials by secretlint"
+    yarn install
+    # Secretlint all selected files
+    echo "$FILES" | xargs yarn secretlint --maskSecrets
+    RET=$?
+    if [ $RET -eq 0 ] ;then
+        exit 0
+    else
+        exit 1
+    fi
+    EOF
+    ```
+    <!-- markdownlint-enable MD013 -->
+
+1. `.git/hooks/pre-commit` に実行権限を付与します。
+
+    ```sh
+    chmod +x .git/hooks/pre-commit
+    ```
+
 ## License
 
 [MIT LICENSE](LICENSE)


### PR DESCRIPTION
secretlintはコミット前に実行するのがもっとも効果が高そうなので、設定方法をREADMEに記述します。