### PR TITLE
clickをdependabotによる更新対象から除外

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
   schedule:
     interval: "daily"
   open-pull-requests-limit: 1
+  ignore:
+    - dependency-name: click
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/Pipfile
+++ b/Pipfile
@@ -9,4 +9,3 @@ autopep8 = "==1.5.7"
 [packages]
 pyperclip = ">=1.5.27"
 click = "==7.1.2"
-slackeventsapi = "==2.2.1"


### PR DESCRIPTION
clickがhato-botと不整合を起こさないようslackeventsapiへの依存を追加しましたが ( https://github.com/dev-hato/sudden-death/pull/103 )、slackeventsapi自体も不整合を起こしそうな状態になっています。
そのため、slackeventsapiへの依存を削除し、clickをdependabotによる更新対象から除外します。