### PR TITLE
CI pr-copy-ci-sudden-death 修正

### DIFF
--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -29,11 +29,10 @@ jobs:
               state: "open",
               ...pull_params
             }
-            console.log("call pulls.list:")
-            console.log(pulls_list_params)
-            const list_res = await github.pulls.list(pulls_list_params)
+            console.log("call pulls.list:", pulls_list_params)
+            const pulls = (await github.pulls.list(pulls_list_params)).data
 
-            if (0 < list_res.data.filter(data => data.user.id === 41898282).length) {
+            if (0 < pulls.filter(data => data.user.id === 41898282).length) {
               return
             }
 
@@ -42,6 +41,5 @@ jobs:
               body: "鳩の唐揚げおいしい！😋😋😋",
               ...pull_params
             }
-            console.log("call pulls.create:")
-            console.log(pulls_create_params)
+            console.log("call pulls.create:, pulls_create_params)
             await github.pulls.create(pulls_create_params)


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/696 のレビューを踏まえてCI `pr-copy-ci-sudden-death` を修正します。
* `console.log` を1行にまとめる
* GitHub APIのレスポンスが入る変数の変数名修正