### PR TITLE
早期returnしている箇所を別のstepに分離する・ページネーション対応

### DIFF
--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -25,7 +25,7 @@ jobs:
               state: "open"
             }
             console.log("call pulls.list:", pulls_list_params)
-            const pulls = (await github.pulls.list(pulls_list_params)).data
+            const pulls = await github.painate(github.pulls.list, pulls_list_params)
             return pulls.filter(data => data.user.id === 41898282).length
       - name: Create PullRequest
         uses: actions/github-script@v3

--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Get pull requests
+      - name: Get PullRequests
         uses: actions/github-script@v3
         id: get_pull_requests
         with:

--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -11,35 +11,35 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Create PullRequest
+      - name: Get pull requests
         uses: actions/github-script@v3
+        id: get_pull_requests
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const common_params = {
+            const pulls_list_params = {
               owner: context.repo.owner,
-              repo: context.repo.repo
-            }
-            const pull_params = {
+              repo: context.repo.repo,
               head: "dev-hato:pr-copy-ci",
               base: "master",
-              ...common_params
-            }
-            const pulls_list_params = {
-              state: "open",
-              ...pull_params
+              state: "open"
             }
             console.log("call pulls.list:", pulls_list_params)
             const pulls = (await github.pulls.list(pulls_list_params)).data
-
-            if (0 < pulls.filter(data => data.user.id === 41898282).length) {
-              return
-            }
-
+            return pulls.filter(data => data.user.id === 41898282).length
+      - name: Create PullRequest
+        uses: actions/github-script@v3
+        if: ${{ steps.get_pull_requests.outputs.result == 0 }}
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
             const pulls_create_params = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head: "dev-hato:pr-copy-ci",
+              base: "master",
               title: "hato-botのCIを反映するよ！",
-              body: "鳩の唐揚げおいしい！😋😋😋",
-              ...pull_params
+              body: "鳩の唐揚げおいしい！😋😋😋"
             }
             console.log("call pulls.create:, pulls_create_params)
             await github.pulls.create(pulls_create_params)


### PR DESCRIPTION
https://github.com/dev-hato/hato-atama/pull/409 でのレビューに基づいて、早期returnしている箇所を別のstepに分離し、stepのifで実行を制御するようにします。
また、GitHub API ( `list*` ) をページネーションに対応させます。