### PR TITLE
CI pr-copy-ci のSyntaxError修正

### DIFF
--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -41,5 +41,5 @@ jobs:
               title: "hato-botのCIを反映するよ！",
               body: "鳩の唐揚げおいしい！😋😋😋"
             }
-            console.log("call pulls.create:, pulls_create_params)
+            console.log("call pulls.create:", pulls_create_params)
             await github.pulls.create(pulls_create_params)


### PR DESCRIPTION
https://github.com/dev-hato/sudden-death/runs/3719279980?check_suite_focus=true

```
SyntaxError: Invalid or unexpected token
```

CI `pr-copy-ci` でクオートが閉じていない箇所があったので修正します。