### PR TITLE
READMEのPythonのバージョンの記載修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Requirements
 
-- Python 3.5 over
+- Python 3.9.10
 - ```pipenv install```
 
 ## Usage


### PR DESCRIPTION
Pythonのバージョンを3.9.10で固定しているので、READMEのPythonのバージョンの記載もそれに合わせます。