### PR TITLE
lintコマンドの除外設定を設定ファイルに記述する

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -2,3 +2,4 @@
 
 [mypy]
 ignore_missing_imports = True
+exclude = ["^node_modules/"]

--- a/.python-lint
+++ b/.python-lint
@@ -14,7 +14,7 @@ ignore=CVS
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.
-ignore-patterns=
+ignore-patterns=node_modules/.*
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
     "lint": "yarn run lint:markdown && yarn run lint:text && yarn run lint:python && yarn run lint:python-type",
     "lint:markdown": "markdownlint -c .markdown-lint.yml -i node_modules .",
     "lint:text": "textlint -c .textlintrc $(find . -name '*.md' | grep -v node_modules)",
-    "lint:python": "pipenv run pylint --rcfile .python-lint $(find . -name '*.py' | grep -v node_modules)",
-    "lint:python-type": "pipenv run mypy --config-file .mypy.ini --install-types --non-interactive $(find . -name '*.py' | grep -v node_modules)"
+    "lint:python": "pipenv run pylint --rcfile .python-lint *.py",
+    "lint:python-type": "pipenv run mypy --config-file .mypy.ini --install-types --non-interactive *.py"
   },
   "devDependencies": {
     "@proofdict/textlint-rule-proofdict": "^3.1.2",


### PR DESCRIPTION
https://github.com/dev-hato/sudden-death/pull/190 をベースに、lintコマンドでの `node_modules/` 除外の設定を可能な限り設定ファイルに記述するようにします。