### PR TITLE
PRを出すCIをPRに関連する部分以外pushでも動かす

### DIFF
--- a/.github/workflows/pr-update-readme-sudden-death.yml
+++ b/.github/workflows/pr-update-readme-sudden-death.yml
@@ -2,6 +2,9 @@ name: pr-update-readme-sudden-death
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
 
 permissions:
   contents: write
@@ -24,7 +27,8 @@ jobs:
         run: |
           result=$(git diff)
           echo "::set-output name=result::$result"
-      - run: |
+      - if: github.event_name == 'pull_request'
+        run: |
           REPO_NAME="${{ github.event.pull_request.head.repo.full_name }}"
           echo "REPO_NAME=${REPO_NAME}" >> "${GITHUB_ENV}"
       # 差分があったときは、コミットを作りpushする
@@ -32,7 +36,8 @@ jobs:
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
-          && steps.diff.outputs.result != '' }}
+          && steps.diff.outputs.result != ''
+          && github.event_name == 'pull_request' }}
         run: |
           git config user.name "github-actions[bot]"
           EMAIL="41898282+github-actions[bot]@users.noreply.github.com"
@@ -49,7 +54,8 @@ jobs:
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
-          && steps.diff.outputs.result != '' }}
+          && steps.diff.outputs.result != ''
+          && github.event_name == 'pull_request' }}
         id: get_pull_requests
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -75,7 +81,8 @@ jobs:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
           && steps.diff.outputs.result != ''
-          && steps.get_pull_requests.outputs.result == 0 }}
+          && steps.get_pull_requests.outputs.result == 0
+          && github.event_name == 'pull_request' }}
         id: create_pull_request
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -104,7 +111,8 @@ jobs:
         if: ${{ env.REPO_NAME == github.repository
           && steps.diff.outputs.result != ''
           && steps.get_pull_requests.outputs.result == 0
-          && github.event.pull_request.user.login != 'dependabot[bot]' }}
+          && github.event.pull_request.user.login != 'dependabot[bot]'
+          && github.event_name == 'pull_request' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -123,7 +131,8 @@ jobs:
         env:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ env.REPO_NAME == github.repository
-          && steps.diff.outputs.result == '' }}
+          && steps.diff.outputs.result == ''
+          && github.event_name == 'pull_request' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |


### PR DESCRIPTION
renovateが出したPRに対してPRが出されていてもマージされるケースがあるようなので ( https://github.com/dev-hato/sudden-death/pull/275 )、PRを出すCIをPRに関連する部分以外pushでも動かすようにして、requiredにします。