### PR TITLE
actions-diff-pr-managementのバージョンを明示的に指定する

### DIFF
--- a/.github/workflows/pr-update-readme-sudden-death.yml
+++ b/.github/workflows/pr-update-readme-sudden-death.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
       - run: sed -i -e "s/Python [0-9.]*/Python $(cat .python-version)/g" README.md
-      - uses: dev-hato/actions-diff-pr-management@main
+      - uses: dev-hato/actions-diff-pr-management@v0.0.1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           branch-name-prefix: readme


### PR DESCRIPTION
https://github.com/dev-hato/actions-diff-pr-management/pull/15 で `actions-diff-pr-management` にバージョンが付与されるようになったので、バージョンを明示的に指定します。