### PR TITLE
PRを出すCIをPRに関連する部分以外pushでも動かす

### DIFF
--- a/.github/workflows/pr-update-readme-sudden-death.yml
+++ b/.github/workflows/pr-update-readme-sudden-death.yml
@@ -2,6 +2,9 @@ name: pr-update-readme-sudden-death
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
 
 permissions:
   contents: write


### PR DESCRIPTION
renovateが出したPRに対してPRが出されていてもマージされるケースがあるようなので ( https://github.com/dev-hato/sudden-death/pull/275 )、PRを出すCIをPRに関連する部分以外pushでも動かすようにして、requiredにします。