### PR TITLE
pr-update-readme-sudden-deathのトリガー修正

### DIFF
--- a/.github/workflows/pr-update-readme-sudden-death.yml
+++ b/.github/workflows/pr-update-readme-sudden-death.yml
@@ -2,6 +2,11 @@ name: pr-update-readme-sudden-death
 
 on:
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
   push:
     branches:
       - master


### PR DESCRIPTION
`dev-hato/actions-diff-pr-management` のアップデートに対応させるため `pr-update-readme-sudden-death` のトリガーを修正します。