### PR TITLE
pr-copy-ci: checkout追加

### DIFF
--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v3.1.0
       - name: Set org name
         uses: actions/github-script@v6.3.3
         id: set_org_name


### PR DESCRIPTION
https://github.com/dev-hato/sudden-death/actions/runs/3448765639/jobs/5756067025

```
Error: Unhandled error: Error: Cannot find module '/home/runner/work/sudden-death/sudden-death/scripts/pr_copy_ci_sudden_death/pr_copy_ci/get_pull_requests.js'
```

上記を修正するため、checkoutのステップを追加します。