### PR TITLE
連続pushした際に古いコミットのCIをキャンセルする

### DIFF
--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -40,3 +40,7 @@ jobs:
           script: |
             const script = require(`${process.env.GITHUB_WORKSPACE}/scripts/pr_copy_ci_sudden_death/pr_copy_ci/create_pull_request.js`)
             await script({github, context})
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/.github/workflows/pr-update-readme-sudden-death.yml
+++ b/.github/workflows/pr-update-readme-sudden-death.yml
@@ -32,3 +32,7 @@ jobs:
           branch-name-prefix: readme
           pr-title-prefix: READMEの記述を直してあげたよ！
           repo-name: ${{ github.event.pull_request.head.repo.full_name }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true


### PR DESCRIPTION
https://zenn.dev/katzumi/articles/using-concurrency-at-github-actions

PRをトリガーとするCIについて、連続pushした際に古いコミットのCIをキャンセルするようにします。