### PR TITLE
forkしたリポジトリでもrenovateが動作するようにする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,5 +12,6 @@
       ],
       "enabled": false
     }
-  ]
+  ],
+  "forkProcessing": "enabled"
 }


### PR DESCRIPTION
https://docs.renovatebot.com/configuration-options/#forkprocessing

renovateがうまく動いていないのは本リポジトリがforkしたリポジトリであるからな気がするので、forkしたリポジトリでも動作するようにしてみます。