### PR TITLE
pr-copy-ci-sudden-death: PRを立てた際に異常終了しないようにする

### DIFF
--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -42,6 +42,7 @@ jobs:
           branch-name-prefix: pr-copy-ci
           pr-title-prefix: hato-botのCIを反映するよ！
           working-directory: sudden-death
+          exit-failure: 'false'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}


### PR DESCRIPTION
hato-botからの差分を反映する際にPRを立ててCIが異常終了するのは気分が良くないので、異常終了しないようにします。