### PR TITLE
pr-copy-ci-sudden-death: workflow_dispatchトリガーにする

### DIFF
--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -1,8 +1,7 @@
 name: pr-copy-ci-sudden-death
 
 on:
-  repository_dispatch:
-    types: pr-copy-ci
+  workflow_dispatch:
 
 jobs:
   # hato-botのCIの差分がpushされたらPRを作成する


### PR DESCRIPTION
`repository_dispatch` トリガーでhato-botからCIを叩く方法だと立てられたPRでCIが動作しないようなので、 `workflow_dispatch`  トリガーに変更して、hato-bot側からAPIでCIを叩くようにしてみます。

hato-bot側PR: https://github.com/dev-hato/hato-bot/pull/3161