### PR TITLE
pr-copy-ci-sudden-death: CIの変更に対応したTokenを使う

### DIFF
--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -14,6 +14,7 @@ jobs:
           fetch-depth: 0
           path: sudden-death
           ref: ${{ github.sha }}
+          token: ${{secrets.CREATE_WORKFLOW_CI_TOKEN}}
       - name: Set org name
         uses: actions/github-script@v6.4.1
         id: set_org_name


### PR DESCRIPTION
https://github.com/dev-hato/sudden-death/actions/runs/5975577907/job/16211821703

```
[detached HEAD f31628b] hato-botのCIを反映するよ！
 11 files changed, 15 insertions(+), 15 deletions(-)
To https://github.com/dev-hato/sudden-death.git
 ! [remote rejected] HEAD -> pr-copy-ci-master (refusing to allow a GitHub App to create or update workflow `.github/workflows/github-actions-cache-cleaner.yml` without `workflows` permission)
```

CIに対する差分をpushできない問題を解消するため、以下のような権限を付与したPATでsudden-deathをcheckoutします。

* Contents: Read and write
* Metadata: Read-only
* Workflows: Read and write