### PR TITLE
pr-copy-ci-sudden-death: masterへのpush時も動作させる

### DIFF
--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -1,6 +1,9 @@
 name: pr-copy-ci-sudden-death
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - master
 jobs:
   # hato-botのCIの差分がpushされたらPRを作成する
   pr-copy-ci:


### PR DESCRIPTION
CI `pr-copy-ci-sudden-death` をmasterへのpush時も動作させることで、PRの差分がmasterに対してlinearになるようにします。