### PR TITLE
CIにGitHub AppのTokenを与える

### DIFF
--- a/.github/workflows/format-json-yml.yml
+++ b/.github/workflows/format-json-yml.yml
@@ -18,15 +18,21 @@ jobs:
   format-json-yml:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1.7.0
+        with:
+          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-          token: ${{secrets.CREATE_WORKFLOW_CI_TOKEN}}
+          token: ${{steps.generate_token.outputs.token}}
       - uses: dev-hato/actions-format-json-yml@v0.0.59
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{steps.generate_token.outputs.token}}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/format-json-yml.yml
+++ b/.github/workflows/format-json-yml.yml
@@ -18,18 +18,17 @@ jobs:
   format-json-yml:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        if: github.event_name != 'pull_request' || github.event.action != 'closed'
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Generate a token
         id: generate_token
         uses: actions/create-github-app-token@v1.7.0
         with:
           app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        if: github.event_name != 'pull_request' || github.event.action != 'closed'
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-          token: ${{steps.generate_token.outputs.token}}
       - uses: dev-hato/actions-format-json-yml@v0.0.59
         with:
           github-token: ${{steps.generate_token.outputs.token}}

--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -9,17 +9,21 @@ jobs:
   pr-copy-ci:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1.7.0
+        with:
+          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
           path: sudden-death
           ref: ${{ github.sha }}
-          token: ${{secrets.GITHUB_TOKEN}}
       - name: Set org name
         uses: actions/github-script@v7.0.1
         id: set_org_name
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
           result-encoding: string
           script: return process.env.GITHUB_REPOSITORY.split('/')[0]
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -32,13 +36,12 @@ jobs:
       - name: Copy package.json
         uses: actions/github-script@v7.0.1
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const script = require(`${process.env.GITHUB_WORKSPACE}/sudden-death/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_package.js`)
             script()
       - uses: dev-hato/actions-diff-pr-management@v1.1.10
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{steps.generate_token.outputs.token}}
           branch-name-prefix: pr-copy-ci
           pr-title-prefix: hato-botのCIを反映するよ！
           working-directory: sudden-death

--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -9,23 +9,17 @@ jobs:
   pr-copy-ci:
     runs-on: ubuntu-latest
     steps:
-      - name: Generate a token
-        id: generate_token
-        uses: actions/create-github-app-token@v1.7.0
-        with:
-          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
           path: sudden-death
           ref: ${{ github.sha }}
-          token: ${{steps.generate_token.outputs.token}}
+          token: ${{secrets.GITHUB_TOKEN}}
       - name: Set org name
         uses: actions/github-script@v7.0.1
         id: set_org_name
         with:
-          github-token: ${{steps.generate_token.outputs.token}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           result-encoding: string
           script: return process.env.GITHUB_REPOSITORY.split('/')[0]
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -38,13 +32,13 @@ jobs:
       - name: Copy package.json
         uses: actions/github-script@v7.0.1
         with:
-          github-token: ${{steps.generate_token.outputs.token}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const script = require(`${process.env.GITHUB_WORKSPACE}/sudden-death/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_package.js`)
             script()
       - uses: dev-hato/actions-diff-pr-management@v1.1.10
         with:
-          github-token: ${{steps.generate_token.outputs.token}}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           branch-name-prefix: pr-copy-ci
           pr-title-prefix: hato-botのCIを反映するよ！
           working-directory: sudden-death

--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -9,12 +9,6 @@ jobs:
   pr-copy-ci:
     runs-on: ubuntu-latest
     steps:
-      - name: Generate a token
-        id: generate_token
-        uses: actions/create-github-app-token@v1.7.0
-        with:
-          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
@@ -39,6 +33,12 @@ jobs:
           script: |
             const script = require(`${process.env.GITHUB_WORKSPACE}/sudden-death/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_package.js`)
             script()
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1.7.0
+        with:
+          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
       - uses: dev-hato/actions-diff-pr-management@v1.1.10
         with:
           github-token: ${{steps.generate_token.outputs.token}}

--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -9,17 +9,23 @@ jobs:
   pr-copy-ci:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1.7.0
+        with:
+          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
           path: sudden-death
           ref: ${{ github.sha }}
-          token: ${{secrets.CREATE_WORKFLOW_CI_TOKEN}}
+          token: ${{steps.generate_token.outputs.token}}
       - name: Set org name
         uses: actions/github-script@v7.0.1
         id: set_org_name
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{steps.generate_token.outputs.token}}
           result-encoding: string
           script: return process.env.GITHUB_REPOSITORY.split('/')[0]
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -32,13 +38,13 @@ jobs:
       - name: Copy package.json
         uses: actions/github-script@v7.0.1
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{steps.generate_token.outputs.token}}
           script: |
             const script = require(`${process.env.GITHUB_WORKSPACE}/sudden-death/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_package.js`)
             script()
       - uses: dev-hato/actions-diff-pr-management@v1.1.10
         with:
-          github-token: ${{secrets.CREATE_WORKFLOW_CI_TOKEN}}
+          github-token: ${{steps.generate_token.outputs.token}}
           branch-name-prefix: pr-copy-ci
           pr-title-prefix: hato-botのCIを反映するよ！
           working-directory: sudden-death


### PR DESCRIPTION
PATを与えているCIについて、基本はデフォルトのトークンで、PR作成時のみGitHub AppのTokenを与えるようにします。