### PR TITLE
GitHub AppのTokenをcheckout時にも使う

### DIFF
--- a/.github/workflows/format-json-yml.yml
+++ b/.github/workflows/format-json-yml.yml
@@ -18,17 +18,18 @@ jobs:
   format-json-yml:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        if: github.event_name != 'pull_request' || github.event.action != 'closed'
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Generate a token
         id: generate_token
         uses: actions/create-github-app-token@v1.7.0
         with:
           app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        if: github.event_name != 'pull_request' || github.event.action != 'closed'
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{steps.generate_token.outputs.token}}
       - uses: dev-hato/actions-format-json-yml@v0.0.59
         with:
           github-token: ${{steps.generate_token.outputs.token}}

--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -9,11 +9,18 @@ jobs:
   pr-copy-ci:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1.7.0
+        with:
+          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
           path: sudden-death
           ref: ${{ github.sha }}
+          token: ${{steps.generate_token.outputs.token}}
       - name: Set org name
         uses: actions/github-script@v7.0.1
         id: set_org_name
@@ -33,12 +40,6 @@ jobs:
           script: |
             const script = require(`${process.env.GITHUB_WORKSPACE}/sudden-death/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_package.js`)
             script()
-      - name: Generate a token
-        id: generate_token
-        uses: actions/create-github-app-token@v1.7.0
-        with:
-          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
       - uses: dev-hato/actions-diff-pr-management@v1.1.10
         with:
           github-token: ${{steps.generate_token.outputs.token}}


### PR DESCRIPTION
https://github.com/dev-hato/sudden-death/actions/runs/7843619428/job/21404345600

```
 ! [remote rejected] HEAD -> pr-copy-ci-master (refusing to allow a GitHub App to create or update workflow `.github/workflows/add-to-task-list.yml` without `workflows` permission)
error: failed to push some refs to 'https://github.com/dev-hato/sudden-death.git'
```

GitHub AppのTokenをcheckout時にも与えるようにすることで、GitHub Actionsの定義を含む差分をpushできるようにします。