### PR TITLE
CI pr-copy-ci: ファイルコピー前に削除する

### DIFF
--- a/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_ci.sh
+++ b/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_ci.sh
@@ -12,11 +12,13 @@ done
 
 for f in $(find hato-bot/scripts -type f | grep -v hato_bot | sed -e "s:hato-bot/::g"); do
   mkdir -p "sudden-death/$(dirname "${f}")"
-  cp -f "hato-bot/${f}" "sudden-death/${f}"
+  rm -rf "sudden-death/${f}"
+  cp "hato-bot/${f}" "sudden-death/${f}"
 done
 
 for f in .markdown-lint.yml .python-lint .textlintrc .gitleaks.toml .mypy.ini .pre-commit-config.yaml .python-version .pep8 .flake8 .python-black .isort.cfg renovate.json; do
-  cp -f hato-bot/${f} sudden-death/
+  rm -f "sudden-death/${f}"
+  cp hato-bot/${f} sudden-death/
 done
 PATTERN_BEFORE="$(grep '^click' sudden-death/Pipfile)"
 PATTERN_AFTER="$(grep '^click' hato-bot/Pipfile)"

--- a/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_ci.sh
+++ b/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_ci.sh
@@ -12,11 +12,11 @@ done
 
 for f in $(find hato-bot/scripts -type f | grep -v hato_bot | sed -e "s:hato-bot/::g"); do
   mkdir -p "sudden-death/$(dirname "${f}")"
-  cp "hato-bot/${f}" "sudden-death/${f}"
+  cp -f "hato-bot/${f}" "sudden-death/${f}"
 done
 
 for f in .markdown-lint.yml .python-lint .textlintrc .gitleaks.toml .mypy.ini .pre-commit-config.yaml .python-version .pep8 .flake8 .python-black .isort.cfg renovate.json; do
-  cp hato-bot/${f} sudden-death/
+  cp -f hato-bot/${f} sudden-death/
 done
 PATTERN_BEFORE="$(grep '^click' sudden-death/Pipfile)"
 PATTERN_AFTER="$(grep '^click' hato-bot/Pipfile)"


### PR DESCRIPTION
CI `pr-copy-ci` でhato-botのファイルをコピーする前に削除するようにします。