### PR TITLE
CI pr-copy-ci-sudden-death: hato-botからのコピー対象に.prettierignore追加

### DIFF
--- a/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_ci.sh
+++ b/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_ci.sh
@@ -16,7 +16,7 @@ for f in $(find hato-bot/scripts -type f | grep -v hato_bot | sed -e "s:hato-bot
 	cp "hato-bot/${f}" "sudden-death/${f}"
 done
 
-for f in .markdown-lint.yml .python-lint .textlintrc .gitleaks.toml .mypy.ini .pre-commit-config.yaml .python-version .pep8 .flake8 .python-black .isort.cfg renovate.json requirements.txt; do
+for f in .markdown-lint.yml .python-lint .textlintrc .gitleaks.toml .mypy.ini .pre-commit-config.yaml .python-version .pep8 .flake8 .python-black .isort.cfg .prettierignore renovate.json requirements.txt; do
 	rm -f "sudden-death/${f}"
 	cp hato-bot/${f} sudden-death/
 done


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/4294 で追加した `.prettierignore` を本リポジトリにコピーするようにします。