### PR TITLE
CI pr-copy-ci-sudden-death: scriptsコピー前に削除する

### DIFF
--- a/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_ci.sh
+++ b/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_ci.sh
@@ -9,7 +9,9 @@ for f in $(find hato-bot/${workflows_path} -type f \
 	-not -name "*hato-bot.yml" | sed -e "s:hato-bot/${workflows_path}/::g"); do
 	yq '(.jobs.*.steps.[] | select(has("with")).with | select(has("repo-name")).repo-name) = "dev-hato/sudden-death"' "hato-bot/${workflows_path}/${f}" >"sudden-death/${workflows_path}/${f}"
 done
-
+for f in $(find sudden-death/scripts -type f | grep -v sudden_death); do
+	rm -rf "$f"
+done
 for f in $(find hato-bot/scripts -type f | grep -v hato_bot | sed -e "s:hato-bot/::g"); do
 	mkdir -p "sudden-death/$(dirname "${f}")"
 	rm -rf "sudden-death/${f}"


### PR DESCRIPTION
hato-botでは既に存在しない `scripts` 以下のファイルが散見されるので、CI `pr-copy-ci-sudden-death` で `scripts` 以下のファイルをコピーする前に既に存在するファイルを一度削除するようにします。