### PR TITLE
CI pr-copy-ci: clickバージョン反映処理削除

### DIFF
--- a/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_ci.sh
+++ b/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_ci.sh
@@ -22,5 +22,3 @@ for f in .markdown-lint.yml .python-lint .textlintrc .gitleaks.toml .mypy.ini .p
 	rm -f "sudden-death/${f}"
 	cp hato-bot/${f} sudden-death/
 done
-PATTERN_AFTER="$(grep click hato-bot/pyproject.toml | sed -e 's/^.*click==\([0-9.]*\)".*$/\1/g')"
-sed -i -e "s/click==[0-9.]*\"/click==${PATTERN_AFTER}\"/g" sudden-death/pyproject.toml


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/4619 にてhato-botの依存関係からclickを削除したので、CI pr-copy-ci内にある、clickのバージョンをsudden-deathに反映する処理を削除します。