### PR TITLE
CI pr-copy-ci: hato-botに存在しないファイルはコピーしない

### DIFF
--- a/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_ci.sh
+++ b/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_ci.sh
@@ -18,7 +18,7 @@ for f in $(find hato-bot/scripts -type f | grep -v hato_bot | sed -e "s:hato-bot
 	cp "hato-bot/${f}" "sudden-death/${f}"
 done
 
-for f in .markdown-lint.yml .python-lint .textlintrc .gitleaks.toml .mypy.ini .pre-commit-config.yaml .pep8 .flake8 .python-black .isort.cfg .prettierignore renovate.json requirements.txt; do
+for f in .markdown-lint.yml .python-lint .textlintrc .gitleaks.toml .mypy.ini .pre-commit-config.yaml .pep8 .flake8 .python-black .isort.cfg renovate.json; do
 	rm -f "sudden-death/${f}"
 	cp hato-bot/${f} sudden-death/
 done


### PR DESCRIPTION
https://github.com/dev-hato/sudden-death/actions/runs/13399189604/job/37425636436

```
cp: cannot stat 'hato-bot/.prettierignore': No such file or directory
cp: cannot stat 'hato-bot/requirements.txt': No such file or directory
```

hato-botに存在しないファイルはコピーしないようにします。