### PR TITLE
masterへのpush時にhato-botのCIを呼び出すCI追加

### DIFF
--- a/.github/workflows/dispatch-pr-format-sudden-death.yml
+++ b/.github/workflows/dispatch-pr-format-sudden-death.yml
@@ -1,0 +1,38 @@
+---
+name: dispatch-pr-format-sudden-death
+on:
+  push:
+    branches:
+      - master
+jobs:
+  dispatch_pr_format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Node.js
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          cache: npm
+          node-version-file: package.json
+      - run: npm ci
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@0d564482f06ca65fa9e77e2510873638c82206f2 # v1.11.5
+        with:
+          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: "hato-bot"
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          github-token: ${{steps.generate_token.outputs.token}}
+          script: |
+            const {tsImport} = require('tsx/esm/api')
+            const {script} = await tsImport(
+              './scripts/dispatch_pr_format_sudden_death/dispatch_pr_format/dispatch_event.ts',
+              process.env.GITHUB_WORKSPACE + '/'
+            )
+            await script(github, context)
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true

--- a/scripts/dispatch_pr_format_sudden_death/dispatch_pr_format/dispatch_event.ts
+++ b/scripts/dispatch_pr_format_sudden_death/dispatch_pr_format/dispatch_event.ts
@@ -1,0 +1,21 @@
+import type { Context } from "@actions/github/lib/context";
+import type { GitHub } from "@actions/github/lib/utils";
+import type { RestEndpointMethodTypes } from "@octokit/plugin-rest-endpoint-methods";
+
+export async function script(
+  github: InstanceType<typeof GitHub>,
+  context: Context,
+) {
+  const actionsCreateWorkflowDispatchParams: RestEndpointMethodTypes["actions"]["createWorkflowDispatch"]["parameters"] =
+    {
+      owner: context.repo.owner,
+      repo: "hato-bot",
+      workflow_id: '.github/workflows/pr-format.yml',
+      ref: "master",
+    };
+  console.log("call actions.createWorkflowDispatch:");
+  console.log(actionsCreateWorkflowDispatchParams);
+  await github.rest.actions.createWorkflowDispatch(
+    actionsCreateWorkflowDispatchParams,
+  );
+}

--- a/scripts/dispatch_pr_format_sudden_death/dispatch_pr_format/dispatch_event.ts
+++ b/scripts/dispatch_pr_format_sudden_death/dispatch_pr_format/dispatch_event.ts
@@ -10,7 +10,7 @@ export async function script(
     {
       owner: context.repo.owner,
       repo: "hato-bot",
-      workflow_id: '.github/workflows/pr-format.yml',
+      workflow_id: ".github/workflows/pr-format.yml",
       ref: "master",
     };
   console.log("call actions.createWorkflowDispatch:");


### PR DESCRIPTION
masterへのpush時にhato-botのCI `pr-format` を実行するCIを追加します。
これにより、sudden-deathのmasterが更新されたらhato-botの `uv.lock` 内にあるsudden-deathのコミットハッシュも更新されるようになります。

hato-bot側PR: https://github.com/dev-hato/hato-bot/pull/4858