### PR TITLE
CI dispatch-pr-format-sudden-death: workflow_id修正

### DIFF
--- a/scripts/dispatch_pr_format_sudden_death/dispatch_pr_format/dispatch_event.ts
+++ b/scripts/dispatch_pr_format_sudden_death/dispatch_pr_format/dispatch_event.ts
@@ -10,7 +10,7 @@ export async function script(
     {
       owner: context.repo.owner,
       repo: "hato-bot",
-      workflow_id: ".github/workflows/pr-format.yml",
+      workflow_id: "pr-format.yml",
       ref: "master",
     };
   console.log("call actions.createWorkflowDispatch:");


### PR DESCRIPTION
https://github.com/dev-hato/sudden-death/actions/runs/13402821674/job/37437086333

```
Error: Unhandled error: HttpError: Workflow does not have 'workflow_dispatch' trigger
```

`workflow_id` をパスではなくファイル名だけにします。