### PR TITLE
CI pr-copy-ci-sudden-death: .eslintrc.ymlをコピーする

### DIFF
--- a/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_ci.sh
+++ b/scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_ci.sh
@@ -18,7 +18,7 @@ for f in $(find hato-bot/scripts -type f | grep -v hato_bot | sed -e "s:hato-bot
 	cp "hato-bot/${f}" "sudden-death/${f}"
 done
 
-for f in .markdown-lint.yml .python-lint .textlintrc .gitleaks.toml .mypy.ini .pre-commit-config.yaml .pep8 .flake8 .python-black .isort.cfg renovate.json; do
+for f in .markdown-lint.yml .python-lint .textlintrc .gitleaks.toml .mypy.ini .pre-commit-config.yaml .pep8 .flake8 .python-black .isort.cfg .eslintrc.yml renovate.json; do
 	rm -f "sudden-death/${f}"
 	cp hato-bot/${f} sudden-death/
 done


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/4963 で追加した `.eslintrc.yml` をhato-botからコピーするようにします。