### PR TITLE
actions/checkoutにpersist-credentials: falseをセットする

### DIFF
--- a/.github/workflows/dispatch-pr-format-sudden-death.yml
+++ b/.github/workflows/dispatch-pr-format-sudden-death.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:

--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -21,11 +21,13 @@ jobs:
           path: sudden-death
           ref: ${{ github.sha }}
           token: ${{steps.generate_token.outputs.token}}
+          persist-credentials: false
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           repository: ${{ github.repository_owner }}/hato-bot
           path: hato-bot
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:

--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -9,18 +9,11 @@ jobs:
   pr-copy-ci:
     runs-on: ubuntu-latest
     steps:
-      - name: Generate a token
-        id: generate_token
-        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
-        with:
-          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           path: sudden-death
           ref: ${{ github.sha }}
-          token: ${{steps.generate_token.outputs.token}}
           persist-credentials: false
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -48,6 +41,12 @@ jobs:
               process.env.GITHUB_WORKSPACE + '/sudden-death/'
             )
             script()
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        with:
+          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
       - uses: dev-hato/actions-diff-pr-management@cea263ca46759ebc8c812b8595be4df129761037 # v2.1.0
         with:
           github-token: ${{steps.generate_token.outputs.token}}

--- a/.github/workflows/pr-update-readme-sudden-death.yml
+++ b/.github/workflows/pr-update-readme-sudden-death.yml
@@ -23,6 +23,7 @@ jobs:
           # submodule: 'recursive'
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: sed -i -e "s/Python [0-9.]*/Python $(yq '.project.requires-python' pyproject.toml | sed -e 's/==//g')/g" README.md
       - uses: dev-hato/actions-diff-pr-management@cea263ca46759ebc8c812b8595be4df129761037 # v2.1.0


### PR DESCRIPTION
https://zenn.dev/shunsuke_suzuki/articles/github-action-checkout-persist-credentials

`actions/checkout` で使ったtokenが後続のstepで使われないよう、 `persist-credentials: false` をセットします。

また、GitHub Appでのtoken生成処理に関して以下を行います。
* checkout時のtokenをデフォルトのものにする
* GitHub Appでtokenを生成するタイミングをtokenを使用する直前にする