### PR TITLE
scriptの宣言方法修正

### DIFF
--- a/.github/workflows/dispatch-pr-format-sudden-death.yml
+++ b/.github/workflows/dispatch-pr-format-sudden-death.yml
@@ -30,7 +30,7 @@ jobs:
           github-token: ${{steps.generate_token.outputs.token}}
           script: |
             const {tsImport} = require('tsx/esm/api')
-            const {script} = await tsImport(
+            const {default: {script}} = await tsImport(
               './scripts/dispatch_pr_format_sudden_death/dispatch_pr_format/dispatch_event.ts',
               process.env.GITHUB_WORKSPACE + '/'
             )

--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           script: |
             const {tsImport} = require('tsx/esm/api')
-            const {script} = await tsImport(
+            const {default: {script}} = await tsImport(
               './scripts/pr_copy_ci_sudden_death/pr_copy_ci/copy_package.ts',
               process.env.GITHUB_WORKSPACE + '/sudden-death/'
             )


### PR DESCRIPTION
https://github.com/dev-hato/sudden-death/actions/runs/17534125712/job/49794936937

```
TypeError: script is not a function
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/ed597411d8f924073f98dfc5c65a23a2325f34cd/dist/index.js:36187:16), <anonymous>:8:1)
    at async main (/home/runner/work/_actions/actions/github-script/ed597411d8f924073f98dfc5c65a23a2325f34cd/dist/index.js:36285:20)
Error: Unhandled error: TypeError: script is not a function
```

https://github.com/dev-hato/sudden-death/pull/3054 により、CIが失敗するようになっているので、 `script` の宣言方法を修正します。