### PR TITLE
Takumiを使う

### DIFF
--- a/.github/workflows/dispatch-pr-format-sudden-death.yml
+++ b/.github/workflows/dispatch-pr-format-sudden-death.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           cache: npm
           node-version-file: package.json
+      - uses: flatt-security/setup-takumi-guard-npm@9a5d797c2085b6326d3a2985c08e3a114b9b88c1 # v1.1.1
       - run: npm ci
       - name: Generate a token
         id: generate_token


### PR DESCRIPTION
Takumiを使うようにします。
working-directoryの指定ができないので ( https://github.com/flatt-security/setup-takumi-guard-npm/issues/2 )、指定なしで問題ない箇所のみ導入しています。