### PR TITLE
actions/checkoutのバージョンコメントを明確にする

### DIFF
--- a/.github/workflows/dispatch-pr-format-sudden-death.yml
+++ b/.github/workflows/dispatch-pr-format-sudden-death.yml
@@ -9,7 +9,7 @@ jobs:
   dispatch_pr_format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Set up Node.js

--- a/.github/workflows/pr-copy-ci-sudden-death.yml
+++ b/.github/workflows/pr-copy-ci-sudden-death.yml
@@ -10,13 +10,13 @@ jobs:
   pr-copy-ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           path: sudden-death
           ref: ${{ github.sha }}
           persist-credentials: false
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           repository: ${{ github.repository_owner }}/hato-bot

--- a/.github/workflows/pr-update-readme-sudden-death.yml
+++ b/.github/workflows/pr-update-readme-sudden-death.yml
@@ -16,7 +16,7 @@ jobs:
   pr-update-readme:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:
           # ここでsubmodule持ってくるとdetached headにcommitして死ぬ


### PR DESCRIPTION
https://github.com/dev-hato/sudden-death/pull/3596 のようにdigestのアップデートにならないよう、actions/checkoutのバージョンコメントを明確にします。